### PR TITLE
fix

### DIFF
--- a/src/components/Logo.css
+++ b/src/components/Logo.css
@@ -17,4 +17,5 @@ path {
     position: relative;
     font-size: 90px;
     font-family: 'Josefin Sans', sans-serif;
+    font-style: italic;
 }


### PR DESCRIPTION
`font-style: italic;` を付けないとsafariでフォントが正しく表示されなかった